### PR TITLE
Optionally act as reverse proxy for app, for quick dev testing in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,6 @@ MAINTAINER Department of the Environment <devops@ris.environment.gov.au>
 
 COPY ./apps ${HTTPD_PREFIX}/htdocs/apps/
 COPY ./includes ${HTTPD_PREFIX}/htdocs/includes/
+COPY ./lib /var/lib/
+
+CMD ["/var/lib/entrypoint.sh"]

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-if [ -z "$PROXY_URL"]
+if [ ! -z "$PROXY_URL"]
 then
-	# no proxy url defined, do nothing
-	true;
-else
-	# proxy url configured, append proxypass config to httpd.conf
+	# if proxy url configured, append ProxyPass config to httpd.conf
 	cat /var/lib/proxy_cfg.conf >> ${HTTPD_PREFIX}/conf/httpd.conf
 fi
 

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$PROXY_URL"]
+then
+	# no proxy url defined, do nothing
+	true;
+else
+	# proxy url configured, append proxypass config to httpd.conf
+	cat /var/lib/proxy_cfg.conf >> ${HTTPD_PREFIX}/conf/httpd.conf
+fi
+
+httpd-foreground

--- a/lib/proxy_cfg.conf
+++ b/lib/proxy_cfg.conf
@@ -1,0 +1,22 @@
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+LoadModule proxy_express_module modules/mod_proxy_express.so
+LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_html_module modules/mod_proxy_html.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
+LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule ssl_module modules/mod_ssl.so
+
+<Location "/">
+    ProxyPass ${PROXY_URL}
+</Location>
+<Location "/includes">
+    ProxyPass "!"
+</Location>
+<Location "/apps">
+    ProxyPass "!"
+</Location>


### PR DESCRIPTION
Add entrypoint and configuration for httpd to be configured as a reverse proxy for requests to other paths (besides /apps and /includes)