### PR TITLE
Improve openshift support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2
+FROM httpd:2.4
 
 MAINTAINER Department of the Environment <devops@ris.environment.gov.au>
 

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+
+# if proxy url configured, append ProxyPass config to httpd.conf
+
+# Regular httpd containers from Docker Hub
 if [ ! -z "$PROXY_URL" ]
 then
-	# if proxy url configured, append ProxyPass config to httpd.conf
 	cat /var/lib/proxy_cfg.conf >> ${HTTPD_PREFIX}/conf/httpd.conf
+fi
+
+# Containers used when building in OpenShift
+if [ ! -z "$HTTPD_MAIN_CONF_PATH" ]
+then
+	cat /var/lib/proxy_cfg.conf >> ${HTTPD_MAIN_CONF_PATH}/httpd.conf
 fi
 
 httpd-foreground


### PR DESCRIPTION
Containers built with OpenShift use a different container with different environment variables.

This adds support for these base containers.